### PR TITLE
MPSDK Sample App - Displaying error dialog on start payment activity and authorization actions

### DIFF
--- a/example/app/src/main/res/values/strings.xml
+++ b/example/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
   <string name="app_name">Donut Counter</string>
   <string name="main_image_description">Graphic of brown donut with pink frosting.</string>
+  <string name="ok">OK</string>
 </resources>


### PR DESCRIPTION
Changed to display authorization and start payment activity errors on screen.

| Start Payment Activity | Authorization |
|---	|---	|
| <img width="370" alt="Screenshot 2024-12-09 at 11 33 18 AM" src="https://github.com/user-attachments/assets/ae215cd2-0e3f-40cd-949f-1d93e6d9ab89">  | <img width="379" alt="Screenshot 2024-12-05 at 12 04 10 PM" src="https://github.com/user-attachments/assets/f36122c6-c062-4429-8327-da2f0e5d5d8c"> |